### PR TITLE
Fix `taxy-magit-section-format-items` to work with emacs-mac

### DIFF
--- a/taxy-magit-section.el
+++ b/taxy-magit-section.el
@@ -405,8 +405,7 @@ the items' values for each column."
                                           (setf window-system-frame
                                                 (cl-loop for frame in (frame-list)
                                                          when (and (frame-visible-p frame)
-                                                                   (memq (framep frame)
-                                                                         '(x w32 ns pgtk)))
+                                                                   (not (eq (framep frame) t)))
                                                          return frame))
                                           (error "taxy-magit-section-format-items: No graphical frame to calculate image size"))))))
                         (_


### PR DESCRIPTION
`(framep)` returns 'mac instead of 'ns on Mitsuharu Yamamoto's Emacs port, but Taxy does not currently consider such frames to be graphical.

See also alphapapa/ement.el#304.