### PR TITLE
Fix: Pass section when adding function to shortdoc.

### DIFF
--- a/taxy.el
+++ b/taxy.el
@@ -396,7 +396,7 @@ defined with a definer defined by `taxy-define-key-definer')."
 (with-eval-after-load 'shortdoc
   (declare-function shortdoc-add-function "shortdoc" (group section elem))
   (mapc (lambda (elem)
-	  (shortdoc-add-function 'taxy nil elem))
+	  (shortdoc-add-function 'taxy "Taxy" elem))
         '((taxy-flatten
            :eval (taxy-flatten
                   (make-taxy


### PR DESCRIPTION
Since shortdoc got an explicit check if a section has been give taxis
code to add it's functions to shortdoc fails (Emacs bug#80297).

Examples are i.e. when calling describe function.

Passing a section fixes this bug, no changes for previous versions of
Emacs beyond that there's a title on top of the shortdoc page.

Fixes #19.